### PR TITLE
Gem::Specification#has_rdoc is deprecated

### DIFF
--- a/rhodes.gemspec
+++ b/rhodes.gemspec
@@ -14,8 +14,6 @@ Gem::Specification.new do |s|
   files = Array.new
   IO.read("Manifest.txt").each_line {|x| files << x.chomp}
   s.files =  files
-  # disable rdoc until we fix the docs
-  s.has_rdoc = false
   s.homepage = %q{http://www.rhomobile.com}
   s.rdoc_options = ["--inline-source", "--charset=UTF-8"]
   s.require_paths = ["lib"]


### PR DESCRIPTION
http://blog.segment7.net/2011/04/01/rubygems-1-7-1
