### PR TITLE
Don't wrap partials in <div>

### DIFF
--- a/lib/framework/rho/render.rb
+++ b/lib/framework/rho/render.rb
@@ -164,7 +164,7 @@ module Rho
       #rho_info 'render content: ' + @content.length.to_s
       if xhr? and options[:use_layout_on_ajax] != true
         options[:layout] = false
-        if @request["headers"]["Transition-Enabled"] == "true"
+        if options[:partial].nil? && @request["headers"]["Transition-Enabled"] == "true"
           @content = "<div>#{@content}</div>"
         end
       elsif options[:layout].nil? or options[:layout] == true


### PR DESCRIPTION
render in some cases wraps content in <div></div> to conform to JQuery Mobile requirements when loading the page using Ajax. Partials should never be so-wrapped, however, since they are by definition a PART of a page. Any wrapping that needs to be done should be done on the content that called render :partial.
