### PR TITLE
If iOS preview cannot open file, show "Open In..." menu

### DIFF
--- a/platform/iphone/Classes/AppManager/AppManager.m
+++ b/platform/iphone/Classes/AppManager/AppManager.m
@@ -441,12 +441,17 @@ BOOL isPathIsSymLink(NSFileManager *fileManager, NSString* path) {
         BOOL result = [docController presentPreviewAnimated:YES];
         
         if (!result) {
+            CGPoint centerPoint = [Rhodes sharedInstance].window.center;
+            CGRect centerRec = CGRectMake(centerPoint.x, centerPoint.y, 0, 0);
+            BOOL isValid = [docController presentOpenInMenuFromRect:centerRec inView:[Rhodes sharedInstance].window animated:YES];
         }    
     }
 }
 
-
-
+- (void)documentInteractionControllerDidEndPreview:(UIDocumentInteractionController *)docController
+{
+    [docController autorelease];
+}
 
 - (void)openDocInteract:(NSString*)url {
 	[self performSelectorOnMainThread:@selector(openDocInteractCommand:) withObject:url waitUntilDone:NO];	


### PR DESCRIPTION
This extends the iOS preview in case the file cannot be shown by preview. It will open the "Open In..." menu to allow the user to select the appropriate app.
