### PR TITLE
Black margin if started app in rotated to landscape mode clockwise

### DIFF
--- a/platform/iphone/Classes/SimpleMainView.m
+++ b/platform/iphone/Classes/SimpleMainView.m
@@ -372,6 +372,7 @@ static BOOL makeHiddenUntilLoadContent = YES;
     
 	CGRect wFrame = frame;
     wFrame.origin.y = 0;
+    wFrame.origin.x = 0;
     webView.frame = wFrame;
     
     webView.autoresizesSubviews = YES;


### PR DESCRIPTION
This change solved the problem when the app is started rotated
 to landscape mode clockwise(270º), the app started with black margin
 in left and all view is shifted to the right. 
The app loses about 20px and it can not see the whole page.
