### PR TITLE
Fix Net::HTTP SSL error.

### DIFF
--- a/lib/extensions/net-http/net/http.rb
+++ b/lib/extensions/net-http/net/http.rb
@@ -629,8 +629,11 @@ module Net   #:nodoc:
         SSL_ATTRIBUTES.each do |name|
           ivname = "@#{name}".intern
           if iv_list.include?(ivname)
-	   
-            ssl_parameters[name] = value if value = instance_variable_get(ivname)
+            value = instance_variable_get(ivname)
+
+            if value
+              ssl_parameters[name] = value
+            end
           end
         end
         if platform != 'Blackberry'


### PR DESCRIPTION
Net::HTTP cannot use SSL due to a syntax error in the original 3.4.2 code. This was fixed in 3.5, but 3.5 has other issues for us on the Motorola ET-1 right now, so it makes more sense to fix this in 3.4.2.
