### PR TITLE
Android screen orientation cannot be set in build.yml

### DIFF
--- a/platform/android/build/android.rake
+++ b/platform/android/build/android.rake
@@ -1262,6 +1262,7 @@ namespace "build" do
       generator.installLocation = 'auto'
       generator.minSdkVer = $min_sdk_level
       generator.maxSdkVer = $max_sdk_level
+      generator.screenOrientation = $android_orientation unless $android_orientation.nil?
 
       generator.usesLibraries['com.google.android.maps'] = true if $use_google_addon_api
       generator.addGooglePush(File.join($androidpath,'Rhodes','PushReceiver.erb')) if $app_config["capabilities"].index 'push'


### PR DESCRIPTION
The screen orientation on Android cannot be forced in build.yml even though documentation says it should be possible. It seems that the ManifestGenerator was updated to allow setting this, but it was never hooked up in the Android build rake file.

This patch hooks that up and now setting "orientation" under "android" works.
