### PR TITLE
Fix for System.open_url

### DIFF
--- a/platform/iphone/Classes/AppManager/AppManager.m
+++ b/platform/iphone/Classes/AppManager/AppManager.m
@@ -441,6 +441,7 @@ BOOL isPathIsSymLink(NSFileManager *fileManager, NSString* path) {
         BOOL result = [docController presentPreviewAnimated:YES];
         
         if (!result) {
+            [docController retain];
             CGPoint centerPoint = [Rhodes sharedInstance].window.center;
             CGRect centerRec = CGRectMake(centerPoint.x, centerPoint.y, 0, 0);
             BOOL isValid = [docController presentOpenInMenuFromRect:centerRec inView:[Rhodes sharedInstance].window animated:YES];
@@ -450,6 +451,7 @@ BOOL isPathIsSymLink(NSFileManager *fileManager, NSString* path) {
 
 - (void)documentInteractionControllerDidEndPreview:(UIDocumentInteractionController *)docController
 {
+	[docController autorelease];
     //[docController release];
     //docController = nil;
 }


### PR DESCRIPTION
The following lines of code need to be added to support iPad 2. Without these lines, iPad 2 crashes on iOS 6 when trying to open the list of available apps to open the file with. This is to support opening files in other apps if file preview cannot read it.
