### PR TITLE
[3.5] Android screen orientation cannot be set in build.yml

### DIFF
--- a/platform/android/build/android.rake
+++ b/platform/android/build/android.rake
@@ -1237,6 +1237,7 @@ namespace "build" do
       generator.installLocation = 'auto'
       generator.minSdkVer = $min_sdk_level
       generator.maxSdkVer = $max_sdk_level
+      generator.screenOrientation = $android_orientation unless $android_orientation.nil?
 
       generator.usesLibraries['com.google.android.maps'] = true if $use_google_addon_api
 


### PR DESCRIPTION
This applies the patch from #109 to the 3-5-stable branch. That patch is as follows:

The screen orientation on Android cannot be forced in build.yml even though documentation says it should be possible. It seems that the ManifestGenerator was updated to allow setting this, but it was never hooked up in the Android build rake file.

This patch hooks that up and now setting "orientation" under "android" works.
