### PR TITLE
[3.5] [Patch] Support four part version numbers and raise an error if the version number can't be parsed

### DIFF
--- a/platform/android/build/android.rake
+++ b/platform/android/build/android.rake
@@ -1192,7 +1192,7 @@ namespace "build" do
 
     task :manifest => ["config:android", :extensions] do
 
-      version = {'major' => 0, 'minor' => 0, 'patch' => 0}
+      version = {'major' => 0, 'minor' => 0, 'patch' => 0, "build" => 0}
       if $app_config["version"]
         if $app_config["version"] =~ /^(\d+)$/
           version["major"] = $1.to_i
@@ -1203,10 +1203,17 @@ namespace "build" do
           version["major"] = $1.to_i
           version["minor"] = $2.to_i
           version["patch"] = $3.to_i
+        elsif $app_config["version"] =~ /^(\d+)\.(\d+)\.(\d+)\.(\d+)$/
+          version["major"] = $1.to_i
+          version["minor"] = $2.to_i
+          version["patch"] = $3.to_i
+          version["build"] = $4.to_i
+        else
+          raise "Version number must be numeric and in one of these formats: major, major.minor, major.minor.patch, or major.minor.patch.build."
         end
       end
 
-      version = version["major"]*10000 + version["minor"]*100 + version["patch"]
+      version = version["major"]*1000000 + version["minor"]*10000 + version["patch"]*100 + version["build"]
       
       usesPermissions = ['android.permission.INTERNET', 'android.permission.PERSISTENT_ACTIVITY', 'android.permission.WAKE_LOCK']
       $app_config["capabilities"].each do |cap|


### PR DESCRIPTION
We had an issue where a 4 part version number would cause a versionCode of 0 to always be generated. This prevents upgrades and breaks our MDM solution, so I fixed the code to support 4 part version numbers. Also, it raises an error if the version number is in an unexpected format rather than working and erroneously setting versionCode to 0.
