### PR TITLE
Patch busy wait to sleep instead

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -2127,6 +2127,7 @@ namespace "run" do
 
         if RUBY_PLATFORM =~ /darwin/
           while 1
+            sleep 1
           end     
         end
     end


### PR DESCRIPTION
Under OSX (only), the Rake task to launch RhoSimulator in debug mode enters an infinite loop in order to avoid exiting. However, this causes the process to skyrocket its CPU usage to 100%.

The proposed patch adds a sleep call of 1 second to eliminate that problem. The process will remain active, but CPU usage becomes negligible.
