### PR TITLE
Fix: undefined method `rm_f' for AndroidTools:Module

### DIFF
--- a/platform/android/build/android_tools.rb
+++ b/platform/android/build/android_tools.rb
@@ -208,7 +208,7 @@ module_function :is_device_running
 def  run_emulator(options = {})
   system("\"#{$adb}\" start-server")
 
-  rm_f $applog_path if !$applog_path.nil?
+  FileUtils.rm_f $applog_path if !$applog_path.nil?
   logcat_process()
   
   unless is_emulator_running
@@ -280,7 +280,7 @@ def  run_emulator(options = {})
               Jake.run($adb, ['start-server'], nil, true)
               adbRestarts += 1
 
-              rm_f $applog_path if !$applog_path.nil?
+              FileUtils.rm_f $applog_path if !$applog_path.nil?
               logcat_process()
             else
               puts "Still waiting..."


### PR DESCRIPTION
undefined method `rm_f' for AndroidTools:Module when running rake
run:android
