### PR TITLE
Workaround for proxy issue

### DIFF
--- a/platform/shared/common/RhodesApp.cpp
+++ b/platform/shared/common/RhodesApp.cpp
@@ -1354,7 +1354,7 @@ void CRhodesApp::initAppUrls()
 {
     CRhodesAppBase::initAppUrls(); 
    
-#if defined( __SYMBIAN32__ ) || defined( OS_ANDROID )
+#if defined( __SYMBIAN32__ )
     m_strHomeUrl = "http://localhost:";
 #elif defined( OS_WINCE ) && !defined(OS_PLATFORM_MOTCE)
     TCHAR oem[257];


### PR DESCRIPTION
Android is not able to load page from "http://localhost" if APN proxy is set and the device is using 3G connectivity (not wifi). It tries to use the APN proxy even for a "localhost" domain instead of connecting locally; that does not work and the WebView is not able to load the home page.

You can reproduce the problem by adding a fake proxy (say, 1.1.1.1) to your APN settings and trying to start a Rhodes app. You will likely receive an error message about the page not being available.

Every now and then, a user comes across this problem and asks about it in Launchpad, see:

https://developer.motorolasolutions.com/thread/3287

and

https://developer.motorolasolutions.com/thread/3873 - here the user reports that this patch fixes the issue for them.

The proposed patch changes the definition of m_strHomeUrl on Android and sets it to http://127.0.0.1 , which should work under all circumstances.
