### PR TITLE
SR EMBPD00120166 and EMBPD00120580 fix

### DIFF
--- a/platform/wm/build/build_inf.js
+++ b/platform/wm/build/build_inf.js
@@ -279,7 +279,7 @@ function pinf(platform,es,exts,name,vendor,srcdir,show_shortcut,is_icon,webkit,
     if (is_persistent)
     {
         p("CopyFiles=CopyToInstallDir,CopyPersistent" +
-           (!usereruntime && webkit ? ",CopyWebKitBinPers,CopyNPAPIPers,CopyConfigPers,CopySystemFiles" : "")+
+           (!usereruntime && webkit ? ",CopyWebKitBinPers,CopyNPAPIPers,CopyConfigPers,CopySystemFilesPers" : "")+
            (!usereruntime && !webkit && include_motocaps? ",CopyConfigPers" : "")+
            get_copyfiles_sections(es,is_persistent));
     }
@@ -385,6 +385,8 @@ function pinf(platform,es,exts,name,vendor,srcdir,show_shortcut,is_icon,webkit,
             p("CopyWebKitBinPers=0,\"Application\\" + name + "\"");
             p("CopyNPAPIPers=0,\"Application\\" + name + "\\NPAPI\"");
             p("CopyConfigPers=0,\"Application\\" + name + "\\Config\"");
+			p("CopySystemFilesPers=0,\"Application\\" + name + "\"");
+			
         }
         else {
             p("CopyWebKitBin=0,\"%InstallDir%\"");


### PR DESCRIPTION
For persistent installation the prtlib.dll was not getting copied into device.In Non pressitent installation it was getting copied into Windows folder.This has been corrected.Now for persistent installation the prtlib.dll gets copied into \Application\RhoElements folder and over cold boot it goes to \Program files\RhoElements folder.
