### PR TITLE
iOS: add callbackAsString to CMethodResult 

### DIFF
--- a/platform/shared/api_generator/iphone/CMethodResult.h
+++ b/platform/shared/api_generator/iphone/CMethodResult.h
@@ -31,6 +31,13 @@
 
 -(void) setResult:(NSObject*)value;
 -(BOOL) hasCallback;
+-(NSString*) callbackAsString;
+-(BOOL) isEqualCallback:(id<IMethodResult>) oCallback;
+
+-(NSString*) getRubyCallbackURL;
+-(unsigned long) getRubyCallbackMethod;
+-(NSString*) getJSCallbackUID;
+-(int) getJSTabIndex;
 
 -(void) setMethodSignature:(NSString*)methodSignature;
 

--- a/platform/shared/api_generator/iphone/CMethodResult.m
+++ b/platform/shared/api_generator/iphone/CMethodResult.m
@@ -180,6 +180,9 @@ extern int rho_webview_active_tab();
 
 
 -(void) setRubyCallback:(NSString*)url {
+    if (mRubyCallbackURL) {
+        [mRubyCallbackURL release];
+    }
     mRubyCallbackURL = [url retain];
 }
 
@@ -194,12 +197,21 @@ extern int rho_webview_active_tab();
 }
 
 -(void) setJSCallback:(NSString*)uid webViewUID:(NSString*)webViewUID {
+    if (mJSCallbackUID) {
+        [mJSCallbackUID release];
+    }
+    if (mJSWebViewUID) {
+        [mJSWebViewUID release];
+    }
     mJSCallbackUID = [uid retain];
     mJSWebViewUID = [webViewUID retain];
     mJSTabIndex = rho_webview_active_tab();
 }
 
 -(void) setCallbackParam:(NSString*)param {
+    if (mCallbackParam) {
+        [mCallbackParam release];
+    }
     mCallbackParam = [param retain];
 }
 
@@ -242,8 +254,61 @@ extern int rho_webview_active_tab();
     }
 }
 
+-(NSString*) getRubyCallbackURL {
+    return mRubyCallbackURL;
+}
+
+-(unsigned long) getRubyCallbackMethod {
+    return mRubyCallbackMethod;
+}
+
+-(NSString*) getJSCallbackUID {
+    return mJSCallbackUID;
+}
+
+-(int) getJSTabIndex {
+    return mJSTabIndex;
+}
+
+-(BOOL) isEqualCallback:(id<IMethodResult>) oCallback {
+    BOOL isCallbackSet = [self hasCallback];
+    if ( !isCallbackSet ) {
+        return ![oCallback hasCallback];
+    } else if (oCallback != nil) {
+        if ([oCallback isKindOfClass:[CMethodResult class]]) {
+            CMethodResult* thatCallback = (CMethodResult*)oCallback;
+            
+            if (mRubyCallbackURL != nil) {
+                return [mRubyCallbackURL isEqualToString:[thatCallback getRubyCallbackURL]];
+            }
+            
+            if (mRubyCallbackMethod != 0 ) {
+                return ([thatCallback getRubyCallbackMethod] == mRubyCallbackMethod );
+            }
+            
+            if (mJSCallbackUID != nil) {
+                return ([mJSCallbackUID isEqualToString:[thatCallback getJSCallbackUID]] && (mJSTabIndex == [thatCallback getJSTabIndex]) );
+            }
+        }
+    }
+    return NO;
+}
+
 -(BOOL) hasCallback {
     return ((mRubyCallbackURL != nil) || (mRubyCallbackMethod != 0) || (mJSCallbackUID != nil));
+}
+
+-(NSString*) callbackAsString {
+    if (mRubyCallbackURL != nil) {
+        return [NSString stringWithFormat:@"rb:%@",mRubyCallbackURL];
+    }
+    if (mRubyCallbackMethod != 0) {
+        return [NSString stringWithFormat:@"rbid:%lu",mRubyCallbackMethod];
+    }
+    if (mRubyCallbackURL != nil) {
+        return [NSString stringWithFormat:@"js:%@_%d",mJSCallbackUID,mJSTabIndex];
+    }
+    return @"";
 }
 
 + (NSObject*) getObjectiveCNULL {

--- a/platform/shared/api_generator/iphone/IMethodResult.h
+++ b/platform/shared/api_generator/iphone/IMethodResult.h
@@ -19,7 +19,9 @@
 
 - (void) setResult:(NSObject*)value;
 
--(BOOL) hasCallback;
+- (BOOL) hasCallback;
+
+- (NSString*) callbackAsString;
 
 @end
 
@@ -30,12 +32,13 @@
     NSObject* resultObject;
 }
 
--(id) init;
+- (id) init;
 
-+(CMethodResult_SimpleHolder*) makeEmptyHolder;
++ (CMethodResult_SimpleHolder*) makeEmptyHolder;
 
 - (void) setResult:(NSObject*)value;
--(BOOL) hasCallback;
+- (BOOL) hasCallback;
+- (NSString*) callbackAsString;
 
 - (NSObject*) getResult;
 


### PR DESCRIPTION
for checking for callback equality and searching in callback queues
