### PR TITLE
[iOS] Make UIApplicationExitsOnSuspend configurable.

### DIFF
--- a/platform/iphone/rbuild/iphone.rake
+++ b/platform/iphone/rbuild/iphone.rake
@@ -1034,8 +1034,8 @@ namespace "build" do
 
       # Set UIApplicationExitsOnSuspend.
       if $app_config["iphone"]["UIApplicationExitsOnSuspend"].nil?
-        puts "UIApplicationExitsOnSuspend not configured, using default of true"
-        set_app_exit_on_suspend(true)
+        puts "UIApplicationExitsOnSuspend not configured, using default of false"
+        set_app_exit_on_suspend(false)
       elsif $app_config["iphone"]["UIApplicationExitsOnSuspend"].to_s.downcase == "true" || $app_config["iphone"]["UIApplicationExitsOnSuspend"].to_s == "1"
         set_app_exit_on_suspend(true)
       elsif $app_config["iphone"]["UIApplicationExitsOnSuspend"].to_s.downcase == "false" || $app_config["iphone"]["UIApplicationExitsOnSuspend"].to_s == "0"
@@ -1086,8 +1086,8 @@ namespace "build" do
 
       # Set UIApplicationExitsOnSuspend.
       if $app_config["iphone"]["UIApplicationExitsOnSuspend"].nil?
-        puts "UIApplicationExitsOnSuspend not configured, using default of true"
-        set_app_exit_on_suspend(true)
+        puts "UIApplicationExitsOnSuspend not configured, using default of false"
+        set_app_exit_on_suspend(false)
       elsif $app_config["iphone"]["UIApplicationExitsOnSuspend"].to_s.downcase == "true" || $app_config["iphone"]["UIApplicationExitsOnSuspend"].to_s == "1"
         set_app_exit_on_suspend(true)
       elsif $app_config["iphone"]["UIApplicationExitsOnSuspend"].to_s.downcase == "false" || $app_config["iphone"]["UIApplicationExitsOnSuspend"].to_s == "0"
@@ -1137,8 +1137,8 @@ namespace "build" do
 
       # Set UIApplicationExitsOnSuspend.
       if $app_config["iphone"]["UIApplicationExitsOnSuspend"].nil?
-        puts "UIApplicationExitsOnSuspend not configured, using default of true"
-        set_app_exit_on_suspend(true)
+        puts "UIApplicationExitsOnSuspend not configured, using default of false"
+        set_app_exit_on_suspend(false)
       elsif $app_config["iphone"]["UIApplicationExitsOnSuspend"].to_s.downcase == "true" || $app_config["iphone"]["UIApplicationExitsOnSuspend"].to_s == "1"
         set_app_exit_on_suspend(true)
       elsif $app_config["iphone"]["UIApplicationExitsOnSuspend"].to_s.downcase == "false" || $app_config["iphone"]["UIApplicationExitsOnSuspend"].to_s == "0"


### PR DESCRIPTION
Not doing anything to restore the value that was previously in the file, because we use defaults to save the value and therefore don't care about the previous value.

Set this by adding a key under "iphone" in build.yml named UIApplicationExitsOnSuspend. Possible values are not specified at all (which defaults to false, the iOS default), true, false, 1, and 0. All others will raise an error and stop the build process.
- Keith Gable @ DecisionPoint (kgable@decisionpt.com)
