### PR TITLE
[Android] Add a configuration option to disable the back button

### DIFF
--- a/platform/android/Rhodes/src/com/rhomobile/rhodes/RhodesActivity.java
+++ b/platform/android/Rhodes/src/com/rhomobile/rhodes/RhodesActivity.java
@@ -347,7 +347,7 @@ public class RhodesActivity extends BaseActivity implements SplashScreen.SplashS
 				return false;
 			
 			// If the RhoConf setting of disable_back_button is set to 1, pretend we did something.
-			if (RhoConf.isExist("disable_back_button") && RhoConf.getString("disable_back_button") == "1") {
+			if (RhoConf.isExist("disable_back_button") && RhoConf.getInt("disable_back_button") == 1) {
 				Logger.D(TAG, "Back button pressed, but back button is disabled in RhoConfig.");
 				return true;
 			} else {


### PR DESCRIPTION
In our application, the logic is very complicated as far as when and if you can go back, so we need a way to kill the back button dead that works across a ton of devices. This patch provides that. The config option is `disable_back_button` and can be set to 1 to disable it.

Note that this does not actually document the configuration option or put it in the default rhoconfig.txt. Whoever does that should probably do that, and also document CAPath and CAFile while they're at it. :)
- Keith Gable @ DecisionPoint (kgable@decisionpt.com)
