### PR TITLE
Loading specific version of rhoelements gems based on app sdkversion

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -753,6 +753,8 @@ namespace "config" do
         #check for RhoElements gem and license
 	    if  !$app_config['re_buildstub']	
             begin
+                # try loading specific gem 
+                gem "rhoelements", "~> #{$app_config['sdkversion']}"
                 require "rhoelements"
                 
                 $rhoelements_features = ""
@@ -972,6 +974,12 @@ def find_ext_ingems(extname)
     $rhodes_extensions = nil
 	  $rhodes_join_ext_name = false
 	
+    # try to load the correct gem for the sdkversion
+    begin
+      gem extname, "~> #{$app_config['sdkversion']}"
+    rescue Exception => e
+      puts "Can't load gem #{extname}, '~> #{$app_config['sdkversion']}' : will use default (commonAPI) or latest available version"
+    end
     require extname
     if $rhodes_extensions
         extpath = $rhodes_extensions[0]

--- a/Rakefile
+++ b/Rakefile
@@ -753,8 +753,10 @@ namespace "config" do
         #check for RhoElements gem and license
 	    if  !$app_config['re_buildstub']	
             begin
-                # try loading specific gem 
-                gem "rhoelements", "~> #{$app_config['sdkversion']}"
+                # try loading specific gem
+                if ENV['RHOHUB_SDKVERSION']
+                  gem "rhoelements", "~> #{ENV['RHOHUB_SDKVERSION']}"
+                end
                 require "rhoelements"
                 
                 $rhoelements_features = ""
@@ -975,10 +977,12 @@ def find_ext_ingems(extname)
 	  $rhodes_join_ext_name = false
 	
     # try to load the correct gem for the sdkversion
-    begin
-      gem extname, "~> #{$app_config['sdkversion']}"
-    rescue Exception => e
-      puts "Can't load gem #{extname}, '~> #{$app_config['sdkversion']}' : will use default (commonAPI) or latest available version"
+    if ENV['RHOHUB_SDKVERSION']
+      begin
+        gem extname, "~> #{ENV['RHOHUB_SDKVERSION']}"
+      rescue Exception => e
+        puts "Can't load gem #{extname}, '~> #{ENV['RHOHUB_SDKVERSION']}' : will use default (commonAPI) or latest available version"
+      end
     end
     require extname
     if $rhodes_extensions


### PR DESCRIPTION
@genywind : This pull request is first made into 4.0.0 stable branch. How to test it:
install various versions of rhoelements gems (4.0.x, 4.1.x), rhoconnect-client gems. 
Use any rhodes app with app_type: rhoelements (or specify extension rhoconnect-client). Change sdkversion in build.yml to 4.0.0 . Specify path to this branch in sdk param. Build an app - latest 4.0.x gem should be picked up and not the 4.1.x.
Once the functionality is verified - I will create additional pull requests  into 4.1. stable & master.