### PR TITLE
Navigation Timeout value was not getting displayed

### DIFF
--- a/lib/commonAPI/coreapi/ext/platform/wm/src/WebViewImpl.cpp
+++ b/lib/commonAPI/coreapi/ext/platform/wm/src/WebViewImpl.cpp
@@ -5,6 +5,7 @@
 #include "rubyext/WebView.h"
 
 //extern "C" HWND getMainWnd();
+extern "C" const wchar_t* rho_wmimpl_getNavTimeOutVal(const wchar_t* szName);
 extern "C" const wchar_t* rho_wmimpl_sharedconfig_getvalue(const wchar_t* szName);
 
 namespace rho {
@@ -21,7 +22,7 @@ public:
 
     CWebViewImpl(): m_nNavigationTimeout(0), m_dZoomPage(1.0), m_nTextZoom(1), CWebViewSingletonBase()
     {
-        convertFromStringW( rho_wmimpl_sharedconfig_getvalue( L"Navigation\\NavTimeout" ), m_nNavigationTimeout );
+        convertFromStringW( rho_wmimpl_getNavTimeOutVal( L"Navigation\\NavTimeout" ), m_nNavigationTimeout );
     }
 
     virtual void getFramework(rho::apiGenerator::CMethodResult& oResult)


### PR DESCRIPTION
Fixing bug for native build. Not able to fetch the data from config.xml  for native build.
