### PR TITLE
Update AndroidFunctionality05.java

### DIFF
--- a/platform/android/Rhodes/src/com/rhomobile/rhodes/osfunctionality/AndroidFunctionality05.java
+++ b/platform/android/Rhodes/src/com/rhomobile/rhodes/osfunctionality/AndroidFunctionality05.java
@@ -47,7 +47,7 @@ class AndroidFunctionality05 extends AndroidFunctionality04 implements AndroidFu
             //account = accounts[0];
             for(int i=0;i<accounts.length;i++)
            	{
-            		if(!(Patterns.EMAIL_ADDRESS.matcher(accounts[i].name).matches()))
+            		if((Patterns.EMAIL_ADDRESS.matcher(accounts[i].name).matches()))
             			{
             				account=accounts[i];
             				break;


### PR DESCRIPTION
Why only explicit google account are to be displayed? The old code was not working in Enterprise devices even though we add a google account. However the old code was working in consumer devices. Hence A general change to include all accounts are done
