### PR TITLE
PB "History:Back" implementation for EBAndroid

### DIFF
--- a/platform/android/Rhodes/src/com/rhomobile/rhodes/webview/RhoWebViewClient.java
+++ b/platform/android/Rhodes/src/com/rhomobile/rhodes/webview/RhoWebViewClient.java
@@ -71,6 +71,12 @@ public class RhoWebViewClient extends WebViewClient
     public boolean shouldOverrideUrlLoading(WebView view, String url) {
         Logger.I(TAG, "Loading URL: " + url);
         
+        //RhoElements implementation of "history:back"
+        if(url.equalsIgnoreCase("history:back")) {
+        	view.goBack();
+        	return true;
+        }
+        
         if (url.contains(".HTM")) 
         {
     	     url=url.replace(".HTML", ".html");


### PR DESCRIPTION
This is a old way of allowing web pages to go back in its history, before window.history.back() was added to browsers.
It is here purely for backwards compatibility with PocketBrowser.
