### PR TITLE
Resolving problem whereby the RhoElements Extension cannot be initialise...

### DIFF
--- a/platform/wm/rhodes/browser/CEBrowserEngine.h
+++ b/platform/wm/rhodes/browser/CEBrowserEngine.h
@@ -136,6 +136,7 @@ private:
     unsigned int      m_dwNavigationTimeout;
     BOOL              m_bLoadingComplete;
     BOOL              m_bNavigationError;
+	bool              m_bInitialised;
 
 
 


### PR DESCRIPTION
...d until the first navigation has happened but the IE engine might navigate to the first page which contains META tags or device javascript.  Issue raised by ST on CE.
