### PR TITLE
Enhancement SR: EMBPD00158375, from 5.1 the default webkit engine will be in process

### DIFF
--- a/lib/build/jake.rb
+++ b/lib/build/jake.rb
@@ -70,7 +70,7 @@ class Jake
 
   def self.normalize_build_yml(yml = $app_config)
     yml['wm'] = {} unless yml['wm'].is_a?(Hash)
-    yml['wm']['webkit_outprocess'] = '1' if yml['wm']['webkit_outprocess'].nil?
+    yml['wm']['webkit_outprocess'] = '0' if yml['wm']['webkit_outprocess'].nil?
   end
 
   def self.set_bbver(bbver)


### PR DESCRIPTION
Currently the default engine was webkit out process. 
Webkit out process is going to be deprecated from 5.1.
Therfore we also need to change the default webkit engine to inprocess.
