### PR TITLE
Update CEBrowserEngine.cpp

### DIFF
--- a/platform/wm/rhodes/browser/CEBrowserEngine.cpp
+++ b/platform/wm/rhodes/browser/CEBrowserEngine.cpp
@@ -667,8 +667,10 @@ HRESULT CEBrowserEngine::Invoke(DISPID dispidMember,
 		//  Test if the user has attempted to navigate back in the history
 		if (wcsicmp(tcURL, L"history:back") == 0)
 		{
-            m_pBrowser->GoBack();
-            break;
+            		m_pBrowser->GoBack();
+        		 *(pdparams->rgvarg[0].pboolVal) = VARIANT_TRUE;
+			retVal = S_OK;
+            		break;
 		}
         if(m_hNavigated==NULL)
             m_hNavigated = CreateEvent(NULL, TRUE, FALSE, L"PB_IEENGINE_NAVIGATION_IN_PROGRESS");


### PR DESCRIPTION
EMBPD00160227 -[EB][CE][IE]: Backbutton(html) does not function as expected on Unable to find the page

Solution- Cancelled the current  navigation when the URL is  history:back, by setting thecancel vriable as VARIANT_TRUE.
Earlier it was showing navigation error when back button is pressed as the application was navigating with the url "history:back"