### PR TITLE
EMBPD00162764

### DIFF
--- a/lib/commonAPI/mediacapture/ext/platform/wm/src/Camera/Camera.cpp
+++ b/lib/commonAPI/mediacapture/ext/platform/wm/src/Camera/Camera.cpp
@@ -9,7 +9,7 @@
 bool CCamera::m_IsCameraRunning = false;
 bool CCamera::m_bRcmLoaded = false;
 bool CCamera::m_bAppHasFocus= true;
-CRcmLoader CCamera::m_Rcm;
+CTriggerMonitor CCamera::m_Rcm;
 HANDLE CCamera::m_hTriggerEvents[eTriggerEventMax] = {NULL, NULL};
 HANDLE CCamera::m_hRegisterTrigger = NULL;
 HANDLE CCamera::m_hTriggerMonitorThread = NULL;

--- a/lib/commonAPI/mediacapture/ext/platform/wm/src/Camera/Camera.h
+++ b/lib/commonAPI/mediacapture/ext/platform/wm/src/Camera/Camera.h
@@ -60,7 +60,7 @@ protected:
 	rho::StringW m_CamType;
 	bool m_PreviewOn; 
 	static bool m_IsCameraRunning;
-	static CRcmLoader m_Rcm;		///<  EMDK Rcm DLL loaded dynamically
+	static CTriggerMonitor m_Rcm;		///<  EMDK Rcm DLL loaded dynamically
 	static HANDLE m_hTriggerEvents[eTriggerEventMax];
 	static HANDLE m_hRegisterTrigger;
 	static HANDLE m_hTriggerMonitorThread;

--- a/lib/commonAPI/mediacapture/ext/platform/wm/src/Camera/TriggerMonitor.cpp
+++ b/lib/commonAPI/mediacapture/ext/platform/wm/src/Camera/TriggerMonitor.cpp
@@ -1,6 +1,6 @@
 #include "TriggerMonitor.h"
 
-CRcmLoader::CRcmLoader()
+CTriggerMonitor::CTriggerMonitor()
 {
 	m_hRcmDLL						= NULL;			
 	lpfn_RCM_Open					= NULL;		
@@ -8,13 +8,13 @@ CRcmLoader::CRcmLoader()
 	lpfn_RCM_DeregisterTrigger		= NULL;
 }
 
-CRcmLoader::~CRcmLoader()
+CTriggerMonitor::~CTriggerMonitor()
 {
 	UnloadRcmDLL();
 }
 
 //  Loading RCM DLL dynamically
-BOOL CRcmLoader::LoadRcmDLL()
+BOOL CTriggerMonitor::LoadRcmDLL()
 {
 	m_hRcmDLL = LoadLibrary(RCM_DLL);
 	if (!m_hRcmDLL)
@@ -41,7 +41,7 @@ BOOL CRcmLoader::LoadRcmDLL()
 		return TRUE;
 }
 
-BOOL CRcmLoader::UnloadRcmDLL()
+BOOL CTriggerMonitor::UnloadRcmDLL()
 {
 	if (m_hRcmDLL)
 	{

--- a/lib/commonAPI/mediacapture/ext/platform/wm/src/Camera/TriggerMonitor.h
+++ b/lib/commonAPI/mediacapture/ext/platform/wm/src/Camera/TriggerMonitor.h
@@ -9,7 +9,7 @@ typedef DWORD (WINAPI* LPFN_RCM_OPEN_T)	(void);
 typedef DWORD (WINAPI* LPFN_RCM_REGISTERTRIGGEREVENT_T)	(DWORD dwTriggerMask, BOOL bExclusive, LPTSTR lpszEventName, LPHANDLE lphHandle);
 typedef DWORD (WINAPI* LPFN_RCM_DEREGISTERTRIGGER_T)	(HANDLE);
 
-class CRcmLoader
+class CTriggerMonitor
 {
 public:
 
@@ -18,8 +18,8 @@ public:
 	LPFN_RCM_REGISTERTRIGGEREVENT_T		lpfn_RCM_RegisterTriggerEvent;	///<  Function pointer to EMDK Rcm API
 	LPFN_RCM_DEREGISTERTRIGGER_T		lpfn_RCM_DeregisterTrigger;		///<  Function pointer to EMDK Rcm API
 
-	CRcmLoader();
-	~CRcmLoader();
+	CTriggerMonitor();
+	~CTriggerMonitor();
 	
 	BOOL LoadRcmDLL();
 	BOOL UnloadRcmDLL();


### PR DESCRIPTION
When “takePicture” method is called application is getting crashed.

Sabir: CRcmLoader class was available in some other obj file aswell. Camera got linked with that obj file which created the problem. renamed the class.