### PR TITLE
Sr timer ios

### DIFF
--- a/lib/commonAPI/coreapi/RhoTimerApi.rb
+++ b/lib/commonAPI/coreapi/RhoTimerApi.rb
@@ -1,0 +1,13 @@
+module Rho
+    class Timer
+        def self.start( interval_ms, callback, callback_data )
+        puts "inside start"
+        System.start_timer(interval_ms, callback, callback_data)
+        end
+
+        def self.stop( callback )
+        puts "inside stop"
+        System.stop_timer( callback )
+        end
+    end
+end

--- a/lib/commonAPI/coreapi/ext/shared/TimerImpl.cpp
+++ b/lib/commonAPI/coreapi/ext/shared/TimerImpl.cpp
@@ -136,4 +136,7 @@ extern "C" void Init_Timer_extension()
 {
     rho::CTimerFactory::setInstance( new rho::CTimerFactory() );
     rho::Init_Timer_API();
+#ifndef RHO_NO_RUBY_API
+    RHODESAPP().getExtManager().requireRubyFile("RhoTimerApi");
+#endif
 }


### PR DESCRIPTION
EMBPD00171080-Rho::Timer.start() method not working
Added the support of 2.2 timer api, which was breaking after implementation of timer common API