### PR TITLE
Eb splashscreen impl for WM/CE device

### DIFF
--- a/platform/wm/rhodes/MainWindow.cpp
+++ b/platform/wm/rhodes/MainWindow.cpp
@@ -73,6 +73,9 @@ extern "C" LRESULT rho_wmimpl_draw_splash_screen(HWND hWnd);
 
 extern "C" double rho_wmimpl_get_pagezoom();
 
+//Reads the "SplashScreenPath" path value from config.xml
+extern "C" const wchar_t* rho_wmimpl_getSplashScreenPathVal();
+
 bool Rhodes_WM_ProcessBeforeNavigate(LPCTSTR url);
 bool m_SuspendedThroughPowerButton = false;
 
@@ -2138,9 +2141,32 @@ extern "C" LRESULT rho_wmimpl_draw_splash_screen(HWND hWnd)
     PAINTSTRUCT ps;
 	HDC hDC = BeginPaint(hWnd, &ps);
 
-    StringW pathW = convertToStringW(RHODESAPP().getLoadingPngPath());
+    StringW pathW;
+
+	LPCTSTR szSplashScreenPath = rho_wmimpl_getSplashScreenPathVal();
+	if (szSplashScreenPath)
+	{
+		pathW = szSplashScreenPath;
+		if (pathW.substr(0,7).compare(_T("file://"))==0)
+		{
+			pathW.erase(0,7);
+		}
+	}
+	else
+	{
+		pathW = convertToStringW(RHODESAPP().getLoadingPngPath());
+	}
 
 	HBITMAP hbitmap = SHLoadImageFile(pathW.c_str());
+
+	if(!hbitmap)
+	{
+		pathW.clear();
+		DeleteObject(hbitmap);
+		LOG(WARNING) + "Specified splashscreen image is not found. Setting the default splashscreen image.";
+		pathW = convertToStringW(RHODESAPP().getLoadingPngPath());
+		hbitmap = SHLoadImageFile(pathW.c_str());
+	}
 		
 	if (hbitmap)
     {

--- a/platform/wm/rhodes/MainWindow.cpp
+++ b/platform/wm/rhodes/MainWindow.cpp
@@ -2163,7 +2163,7 @@ extern "C" LRESULT rho_wmimpl_draw_splash_screen(HWND hWnd)
 	{
 		pathW.clear();
 		DeleteObject(hbitmap);
-		LOG(WARNING) + "Specified splashscreen image is not found. Setting the default splashscreen image.";
+		LOG(WARNING) + "Specified splashscreen image is not found or supported. Setting the default splashscreen image.";
 		pathW = convertToStringW(RHODESAPP().getLoadingPngPath());
 		hbitmap = SHLoadImageFile(pathW.c_str());
 	}


### PR DESCRIPTION
User should be able to change splash screen image on WM/CE platforms via Config.xml

Accepted Criteria:

1) Should be able to change the splash screen image from config.xml on WM/CE platforms.  

  <SplashScreen>
        <SplashScreenPath value="file://%INSTALLDIR%\rho\apps\app\loading.png"/>                
  </SplashScreen>

2) On relaunching the application, the configured splash screen image should be reflected.

3) The path which is set should be present locally in the device.
=> The splash screen image can be present anywhere in the device(The path should be valid). For Ex:

The below examples configures the splash screen image which is present in the "\Test" directory with the name as "splashscreen.png" or "splashscreen.bmp"

  <SplashScreen>
        <SplashScreenPath value="file://\Test\splashscreen.png"/>                
  </SplashScreen>

4) No external path allowed which is present in some server loc
=> It displays the default splash screen image and in the log it displays the warning message as "Specified splashscreen image is not found or supported. Setting the default splashscreen image."

5)  If the user is setting the invalid path, then it should display the default splash screen image.
=> It displays the default splash screen image and in the log it displays the warning message as "Specified splashscreen image is not found or supported. Setting the default splashscreen image."

6) If the user is setting the image other "png" or "bmp" format then it should display the default splash screen image.
=> It displays the default splash screen image if the image format is not of type "png" or "bmp" and in the log it displays the warning message as "Specified splashscreen image is not found or supported. Setting the default splashscreen image."
