### PR TITLE
made stopDetectingConnection callback as optional. also updated xml document.

### DIFF
--- a/lib/commonAPI/coreapi/ext/Network.xml
+++ b/lib/commonAPI/coreapi/ext/Network.xml
@@ -339,9 +339,9 @@ The ebapi.js file is necessary for all single API inclusions.
                 </CALLBACK>
             </METHOD>
 
-            <METHOD name="stopDetectingConnection" hasCallback="mandatory">
+            <METHOD name="stopDetectingConnection" hasCallback="optional">
                 <VER_INTRODUCED>4.0.0</VER_INTRODUCED>
-                <DESC>Ceases the network detection identified by the given callback.</DESC>
+                <DESC>Ceases the network detection. Callback is no more supported.</DESC>
             </METHOD>
 
             <METHOD name="connectWan" hasCallback="mandatory">


### PR DESCRIPTION
Earlier we supported multiple detectConnection threads running parallely. That time we supported stopping a particular detectConnection thread using callback id as identifier.

This feature is no more supported. But we need to support backward compatibility of written app. Hence decide to make this callback as optional. 

As stoping thread is the only job of stopDetectingConnection,  running it synchronously does not hit performance.