### PR TITLE
EMBPD00180707

### DIFF
--- a/lib/commonAPI/coreapi/ext/platform/wm/src/Keyboard.cpp
+++ b/lib/commonAPI/coreapi/ext/platform/wm/src/Keyboard.cpp
@@ -76,7 +76,8 @@ void CSIP::InitSIP()
 		pfnSetKeyState = (LPFNSETKEYSTATE)GetProcAddress(hKeybdDriver, SETKEYSTATE);
 		if (pfnSetKeyState)
 		{
-			pfnSetKeyState(UN_SHIFTED, 0, true);
+			//EMBPD00180707
+			//pfnSetKeyState(UN_SHIFTED, 0, true);
 		}
 	}
 	
@@ -401,7 +402,8 @@ BOOL CSIP::ToggleSystemSIP()
 	{
 		if (pfnSetKeyState)
 		{
-			pfnSetKeyState(UN_SHIFTED, 0, true);
+			//EMBPD00180707
+			//pfnSetKeyState(UN_SHIFTED, 0, true);
 		}
 	}
 

--- a/platform/wm/rhodes/EditSIP.cpp
+++ b/platform/wm/rhodes/EditSIP.cpp
@@ -28,7 +28,8 @@ void CEditSIP::InitSIP()
 		pfnSetKeyState = (LPFNSETKEYSTATE)GetProcAddress(hKeybdDriver, SETKEYSTATE);
 		if (pfnSetKeyState)
 		{
-			pfnSetKeyState(UN_SHIFTED, 0, true);
+			//EMBPD00180707
+			//pfnSetKeyState(UN_SHIFTED, 0, true);
 		}
 	}
 }
@@ -42,7 +43,8 @@ BOOL CEditSIP::ToggleSystemSIP()
 	{
 		if (pfnSetKeyState)
 		{
-			pfnSetKeyState(UN_SHIFTED, 0, true);
+			//EMBPD00180707
+			//pfnSetKeyState(UN_SHIFTED, 0, true);
 		}
 	}
 


### PR DESCRIPTION
With the 43 key keypad, the Alpha key light indicator turns on when starting Enterprise Browser on the MC92N0

commented all code across EB/RMS that explicitly set the keystate to ALPHA while initialising sip