### PR TITLE
EMBPD00182143fix-android badlink page back issue

### DIFF
--- a/platform/android/Rhodes/src/com/rhomobile/rhodes/webview/RhoWebViewClient.java
+++ b/platform/android/Rhodes/src/com/rhomobile/rhodes/webview/RhoWebViewClient.java
@@ -125,7 +125,15 @@ public class RhoWebViewClient extends WebViewClient
         
         //RhoElements implementation of "history:back"
         if(url.equalsIgnoreCase("history:back")) {
+        	Logger.I(TAG, "history:back");
         	view.goBack();
+        	return true;
+        }
+        else if(url.equalsIgnoreCase("history:twiceback")) 
+        {
+            Logger.I(TAG, "history:twiceback");
+        	view.goBack();
+		view.goBack();
         	return true;
         }
         


### PR DESCRIPTION
EMBPD00182143fix-android badlink page back issue-Introduce a new command to go back in history twice.This can be used from badlink page,where Kitkat web engine also introduces its own "webpage not available" page before we move to our own badlink page.

@motobhakta :kindly review it.
@malayap47 :kindly review it.