### PR TITLE
Fix for JIRA id: MC-113715

### DIFF
--- a/lib/commonAPI/mediacapture/RhoCameraApi.rb
+++ b/lib/commonAPI/mediacapture/RhoCameraApi.rb
@@ -42,7 +42,7 @@ if Rho::System.platform == 'APPLE' || Rho::System.platform == 'ANDROID' || Rho::
             end
 
             cam_type = 'back' if cam_type == 'main'
-            if Rho::System.platform != 'APPLE' 
+            if Rho::System.platform != 'APPLE' && Rho::System.platform != 'ANDROID'
               unless options['fileName']
                   options['fileName'] = File.join(Rho::RhoApplication.get_blob_folder(), Rho::RhoConfig.generate_id.to_s)
               end


### PR DESCRIPTION
When take_picture was called without any properties in RE2.2, fileName property was appearing in property map.