### PR TITLE
spr suspected error fix

### DIFF
--- a/platform/wm/rhodes/browser/CEBrowserEngine.cpp
+++ b/platform/wm/rhodes/browser/CEBrowserEngine.cpp
@@ -554,14 +554,14 @@ HRESULT CEBrowserEngine::TranslateAccelerator(
 		}
 	}
 */
-	if (lpMsg && (lpMsg->message == WM_KEYDOWN))
+/*	if (lpMsg && (lpMsg->message == WM_KEYDOWN))
 	{
 		if (lpMsg->wParam == VK_LEFT ||	lpMsg->wParam == VK_RIGHT || lpMsg->wParam == VK_UP || lpMsg->wParam == VK_DOWN || lpMsg->wParam == VK_RETURN)
 		{
 			//EMBPD00174595 - Prevent duplicate left, right, up, down & enter keys
 			return S_OK;
 		}
-	}
+	} */
 	return S_FALSE;
 }
 

--- a/platform/wm/rhodes/browser/CEBrowserEngine.cpp
+++ b/platform/wm/rhodes/browser/CEBrowserEngine.cpp
@@ -958,6 +958,7 @@ void CEBrowserEngine::RunMessageLoop(CMainWindow& mainWnd)
 	
     while (GetMessage(&msg, NULL, 0, 0))
     {
+    	        HRESULT handleKey = S_FALSE;
 		// Used for Zoom-In Or Zoom-Out, if the return value is true then 
 		// the message will be pushed further so that the remaining action 
 		// on that function key can be processed.
@@ -1010,14 +1011,22 @@ void CEBrowserEngine::RunMessageLoop(CMainWindow& mainWnd)
 			{
 				IOleInPlaceActiveObject* pInPlaceObject;
 				pDisp->QueryInterface( IID_IOleInPlaceActiveObject, (void**)&pInPlaceObject);
-				HRESULT handleKey = pInPlaceObject->TranslateAccelerator(&msg);
+				handleKey = pInPlaceObject->TranslateAccelerator(&msg);
 			}
 		}
 
-		if (!mainWnd.TranslateAccelerator(&msg))
+	if(handleKey != S_OK)
+  		{
+  		
+  			if (!mainWnd.TranslateAccelerator(&msg))
+  			{
+  				TranslateMessage(&msg);
+ 				DispatchMessage(&msg);
+  			}
+  		}
+  	else
 		{
-			TranslateMessage(&msg);
-			DispatchMessage(&msg);
+			LOG(INFO)+"HandleKey S_OK";
 		}
 
 		if(msg.message == WM_PAINT)


### PR DESCRIPTION


The thread needs to be handled in a better way so that waitforsingleobject can return only two values either timeout or event singald.  Felt like docthread entering to the code which invoke navigation timeout due to a bug a third case is causing the code to execute.

The developer assumes that his code executes if and only if 45 second is met. However it can enter inside this loop if some error (such as he set pEng->m_hDocComp to NULL many case)

so for the time beigng code is protected to execute if only timeout happens.
