### PR TITLE
Fix bad ppi on ipad mini retina

### DIFF
--- a/platform/iphone/Classes/AppManager/AppManager.m
+++ b/platform/iphone/Classes/AppManager/AppManager.m
@@ -48,6 +48,8 @@
 #import "common/app_build_configs.h"
 
 #include <sys/xattr.h>
+#include <sys/types.h>
+#include <sys/sysctl.h>
 
 #undef DEFAULT_LOGCATEGORY
 #define DEFAULT_LOGCATEGORY "RhodesApp"
@@ -764,6 +766,7 @@ static const double RHO_IPHONE_PPI = 163.0;
 static const double RHO_IPHONE4_PPI = 326.0;
 // http://www.apple.com/ipad/specs/
 static const double RHO_IPAD_PPI = 132.0;
+static const double RHO_IPAD_MINI_PPI = 163.0;
 static const double RHO_NEW_IPAD_PPI = 264.0;
 
 static float get_scale() {
@@ -833,10 +836,26 @@ int rho_sysimpl_get_property_iphone(char* szPropName, NSObject** resValue)
     }
     else if (strcasecmp("ppi_x", szPropName) == 0 ||
              strcasecmp("ppi_y", szPropName) == 0) {
+		
 #ifdef __IPHONE_3_2
+		
         if (UI_USER_INTERFACE_IDIOM() == UIUserInterfaceIdiomPad) {
-            if (get_scale() > 1.2) {
-                *resValue = [NSNumber numberWithDouble:RHO_NEW_IPAD_PPI];
+			
+			//Fix DPI issue on Ipad Mini
+			//get the device model name
+			size_t size;
+			sysctlbyname("hw.machine", NULL, &size, NULL, 0);
+			char *machine = malloc(size);
+			sysctlbyname("hw.machine", machine, &size, NULL, 0);
+			NSString *platform = [NSString stringWithUTF8String:machine];
+			free(machine);
+				
+			// IPad Mini
+			if([platform isEqualToString:@"iPad2,5"] || [platform isEqualToString:@"iPad2,6"] || [platform isEqualToString:@"iPad2,7"]){
+				*resValue = [NSNumber numberWithDouble:RHO_IPAD_MINI_PPI];
+			}
+		    else if (get_scale() > 1.2) {
+		        *resValue = [NSNumber numberWithDouble:RHO_NEW_IPAD_PPI];
             }
             else {
                 *resValue = [NSNumber numberWithDouble:RHO_IPAD_PPI];

--- a/platform/iphone/Classes/AppManager/AppManager.m
+++ b/platform/iphone/Classes/AppManager/AppManager.m
@@ -766,8 +766,9 @@ static const double RHO_IPHONE_PPI = 163.0;
 static const double RHO_IPHONE4_PPI = 326.0;
 // http://www.apple.com/ipad/specs/
 static const double RHO_IPAD_PPI = 132.0;
-static const double RHO_IPAD_MINI_PPI = 163.0;
 static const double RHO_NEW_IPAD_PPI = 264.0;
+static const double RHO_IPAD_MINI_PPI = 163.0;
+static const double RHO_IPAD_MINI_RETINA_PPI = 326.0;
 
 static float get_scale() {
     float scales = 1;//[[UIScreen mainScreen] scale];
@@ -836,9 +837,7 @@ int rho_sysimpl_get_property_iphone(char* szPropName, NSObject** resValue)
     }
     else if (strcasecmp("ppi_x", szPropName) == 0 ||
              strcasecmp("ppi_y", szPropName) == 0) {
-		
 #ifdef __IPHONE_3_2
-		
         if (UI_USER_INTERFACE_IDIOM() == UIUserInterfaceIdiomPad) {
 			
 			//Fix DPI issue on Ipad Mini
@@ -854,6 +853,10 @@ int rho_sysimpl_get_property_iphone(char* szPropName, NSObject** resValue)
 			if([platform isEqualToString:@"iPad2,5"] || [platform isEqualToString:@"iPad2,6"] || [platform isEqualToString:@"iPad2,7"]){
 				*resValue = [NSNumber numberWithDouble:RHO_IPAD_MINI_PPI];
 			}
+            // IPad Mini Retina
+            else if ([platform isEqualToString:@"iPad4,4"] || [platform isEqualToString:@"iPad4,5"] || [platform isEqualToString:@"iPad4,6"] || [platform isEqualToString:@"iPad4,7"] || [platform isEqualToString:@"iPad4,8"] || [platform isEqualToString:@"iPad4,9"] || [platform isEqualToString:@"iPad5,1"] || [platform isEqualToString:@"iPad5,2"]) {
+                *resValue = [NSNumber numberWithDouble:RHO_IPAD_MINI_RETINA_PPI];
+            }
 		    else if (get_scale() > 1.2) {
 		        *resValue = [NSNumber numberWithDouble:RHO_NEW_IPAD_PPI];
             }


### PR DESCRIPTION
Hi,

Actually, rhodes return bad ppi for some devices on iOS. It's the case for all the ipad mini, because they don't have the same ppi than ipad pro or iphone.

You can easly check ppi with this great wiki that listed all the ppi for each device : 
[https://www.theiphonewiki.com/wiki/Models](url)

More over, I don't try for the moment, but it seems that for iphone 6 plus, 6s plus and 7 plus, the correct ppi is 401 and rhodes don't manage it like for the ipad mini.

Thanks :)