### PR TITLE
Generate unique identifier for iOS

### DIFF
--- a/lib/commonAPI/coreapi/ext/platform/iphone/cpp_based_impl/SystemImpl.mm
+++ b/lib/commonAPI/coreapi/ext/platform/iphone/cpp_based_impl/SystemImpl.mm
@@ -138,8 +138,7 @@ namespace rho {
     
     void SystemImplIphone::getPhoneId(rho::apiGenerator::CMethodResult& result)
     {
-        //getIphoneProperty("phone_id", result);
-        result.set("");
+        getIphoneProperty("phone_id", result);
     }
     
     void SystemImplIphone::getDeviceName(rho::apiGenerator::CMethodResult& result)

--- a/lib/commonAPI/coreapi/ext/system.xml
+++ b/lib/commonAPI/coreapi/ext/system.xml
@@ -98,7 +98,7 @@ Be sure to review the [Ruby API Usage](/guide/api_ruby) guide for important info
             </PROPERTY>
             <PROPERTY name="phoneId" type="STRING" readOnly="true">
                 <DESC>Hardware based ID. It depends on capabilities configured for an application and has to remain same even across application uninstall/install.</DESC>
-                <PLATFORM>WM, CE, Android</PLATFORM>
+                <PLATFORM>WM, CE, iOS, Android</PLATFORM>
             </PROPERTY>
             <PROPERTY name="deviceName" type="STRING" readOnly="true">
                 <DESC>Name of device application running on. Examples: '9000' (BB), 'iPhone', 'dream' (Android). In Consumer Android device, name of the Industrial Design along with manufacturer name shall be shown. </DESC>

--- a/platform/iphone/Classes/AppManager/AppManager.m
+++ b/platform/iphone/Classes/AppManager/AppManager.m
@@ -787,6 +787,24 @@ int rho_sysimpl_get_property_iphone(char* szPropName, NSObject** resValue)
 {
     if (strcasecmp("platform", szPropName) == 0)
     {*resValue = [NSString stringWithUTF8String:"APPLE"]; return 1;}
+    else if (strcasecmp("phone_id", szPropName) == 0){
+        NSString* uniqueIdentifier = nil;
+        if( [UIDevice instancesRespondToSelector:@selector(identifierForVendor)] ) {
+            // iOS 6+
+            uniqueIdentifier = [[[UIDevice currentDevice] identifierForVendor] UUIDString];
+        } else {
+            // before iOS 6, so just generate an identifier and store it
+            uniqueIdentifier = [[NSUserDefaults standardUserDefaults] objectForKey:@"identiferForVendor"];
+            if( !uniqueIdentifier ) {
+                CFUUIDRef uuid = CFUUIDCreate(NULL);
+                uniqueIdentifier = (NSString*)CFUUIDCreateString(NULL, uuid);
+                CFRelease(uuid);
+                [[NSUserDefaults standardUserDefaults] setObject:uniqueIdentifier forKey:@"identifierForVendor"];
+            }
+        }
+        *resValue = uniqueIdentifier;
+        return 1;
+    }
     else if (strcasecmp("locale", szPropName) == 0)
     {*resValue = rho_sys_get_locale_iphone(); return 1; }
     else if (strcasecmp("country", szPropName) == 0) {


### PR DESCRIPTION
Hi,

We find a workaround in order to generate an unique identifier for iOS devices.

We use the identifierForVendor method in order to generate this unique identifier per app and per vendor. This identifierForVendor is only available for iOS 6.0+ but before this version we generate an identifier and store it in the default storage.

Full doc here : [https://developer.apple.com/reference/uikit/uidevice/1620059-identifierforvendor](url)

Thanks :)