### PR TITLE
Fix : recursive_replace_bool for first level boolean properties

### DIFF
--- a/platform/iphone/rbuild/iphone.rake
+++ b/platform/iphone/rbuild/iphone.rake
@@ -365,7 +365,7 @@ def update_plist_procedure
             info_plist_data = $app_config["iphone"]["info_plist_data"]
             if info_plist_data.kind_of?(Hash)
                 info_plist_data.each do |key, value|
-                    recursive_replace_bool(value)
+                    value = recursive_replace_bool(value)
                     recursive_merge_hash(hash, key, value)
                 end
             end


### PR DESCRIPTION
This PR fixes a problem with first level info_plit_data.
If i had in my build.yml an Info.plist boolean property on the first level, the boolean value was considerd as a string. 
Example in build.yml : 
```yml
info_plist_data:
  UIStatusBarHidden: true
```
It generates in the Info.plist : 
```xml
<key>UIStatusBarHidden</key>
<string>true</string>
```
Instead of : 
```xml
<key>UIStatusBarHidden</key>
<true/>
```