### PR TITLE
Fix Rho.Application.expandDatabaseBlobFilePath. Was: the method retur…

### DIFF
--- a/lib/commonAPI/coreapi/ext/shared/ApplicationImpl.cpp
+++ b/lib/commonAPI/coreapi/ext/shared/ApplicationImpl.cpp
@@ -176,6 +176,9 @@ public:
             String dbRootFolder = CFilePath::join( rho_native_rhodbpath(), RHO_EMULATOR_DIR);
             if ( !String_startsWith(relativePath, dbRootFolder) )
                 oResult.set( CFilePath::join( dbRootFolder, relativePath ) );
+            else {
+                oResult.set(relativePath);
+            }
         }
     }
 


### PR DESCRIPTION
…ns null if the arg is an absolute path and it does not match with the path to the app root. Now: it returns the arg