### PR TITLE
android : Add intent chooser option

### DIFF
--- a/lib/commonAPI/coreapi/ext/Intent.xml
+++ b/lib/commonAPI/coreapi/ext/Intent.xml
@@ -107,6 +107,14 @@ Sample Build.yml
 
 </DESC>
                             </PARAM>
+                            <PARAM name="createChooser" type="BOOLEAN">
+                                <DESC>Wrap the intent in an action chooser that display the list of available services that can handle the intent. See : <![CDATA[ <a href="https://developer.android.com/reference/android/content/Intent.html#createChooser(android.content.Intent,%20java.lang.CharSequence)">Intent.createChooser</a>.]]>
+</DESC>
+                            </PARAM>
+                            <PARAM name="chooserTitle" type="STRING">
+                                <DESC>Set the chooser title if 'createChooser' is enabled. See : <![CDATA[ <a href="https://developer.android.com/reference/android/content/Intent.html#createChooser(android.content.Intent,%20java.lang.CharSequence)">Intent.createChooser</a>.]]>
+</DESC>
+                            </PARAM>
                          </PARAMS>
                     </PARAM>
                 </PARAMS>

--- a/lib/commonAPI/coreapi/ext/platform/android/src/com/rho/intent/IntentSingleton.java
+++ b/lib/commonAPI/coreapi/ext/platform/android/src/com/rho/intent/IntentSingleton.java
@@ -31,6 +31,8 @@ public class IntentSingleton extends AbstractRhoListener implements IIntentSingl
     private IMethodResult methodResult;
     private IntentReceiver mReceiver = new IntentReceiver();
    
+    private static final String HK_CREATE_CHOOSER = "createChooser";
+    private static final String HK_CHOOSER_TITLE = "chooserTitle";
     
     private List<Map.Entry<Integer, IMethodResult>> localMethodResults = new ArrayList<Map.Entry<Integer, IMethodResult>>();
 
@@ -54,6 +56,8 @@ public class IntentSingleton extends AbstractRhoListener implements IIntentSingl
         Object uriObj = params.get(HK_URI);
         Object mimeObj = params.get(HK_MIME_TYPE);
         Object extrasObj = params.get(HK_DATA);
+        Object createChooserObj = params.get(HK_CREATE_CHOOSER);
+        Object chooserTitleObj = params.get(HK_CHOOSER_TITLE);
 
         String action = null;
         List<String> categories = null;
@@ -62,6 +66,8 @@ public class IntentSingleton extends AbstractRhoListener implements IIntentSingl
         String uri = null;
         String mime = null;
         Map<String, Object> extras = null;
+        Boolean createChooser = null;
+        String chooserTitle = null;
 
         //--- Check param types ---
 
@@ -116,7 +122,21 @@ public class IntentSingleton extends AbstractRhoListener implements IIntentSingl
             }
             extras = (Map<String, Object>)extrasObj;
         }
+
+        if (createChooserObj != null) {
+            if (!Boolean.class.isInstance(createChooserObj)) {
+                throw new RuntimeException("Wrong intent createChooser: " + createChooserObj.toString());
+            }
+            createChooser = (Boolean)createChooserObj;
+        }
         
+        if (chooserTitleObj != null) {
+            if (!String.class.isInstance(chooserTitleObj)) {
+                throw new RuntimeException("Wrong intent chooserTitle: " + chooserTitleObj.toString());
+            }
+            chooserTitle = (String)chooserTitleObj;
+        }
+
         //--- Fill intent fields ---
         
         if (action != null) { 
@@ -201,6 +221,10 @@ public class IntentSingleton extends AbstractRhoListener implements IIntentSingl
                     throw new RuntimeException("Wrong intent data: " + entry.getValue().getClass().getName() + " is not supported as value");
                 }
             }
+        }
+        
+        if (createChooser != null && createChooser){
+            intent = Intent.createChooser(intent, chooserTitle);
         }
         
         return intent;


### PR DESCRIPTION
Add the parameters `createChooser` and `chooserTitle` to the rhodes Intent API. If the `createChooser` param is set to true, it wraps the intent in an action chooser that display the list of available services that can handle the intent. The `chooserTitle` param is used to set the title of the chooser popup.
[Android doc](https://developer.android.com/reference/android/content/Intent.html#createChooser(android.content.Intent,%20java.lang.CharSequence))

Three remarks : 
- I didn't find where are defined the HK_*** constants used by IntentSingleton so I add mine in the singleton class.
- I modified the API doc file Intent.xml but i didn't find how to generate the docs to be sure my modification is well formatted.
- I would prefer to create the PR to the master branch but it seems that some commits in the 5-5-stable branch haven't been merged in the master branch. Is it normal? 
