### PR TITLE
updated cmd params for new SDK;

### DIFF
--- a/platform/android/build/android.rake
+++ b/platform/android/build/android.rake
@@ -626,7 +626,7 @@ namespace "config" do
       apilevel = nil
       target_name = nil
 
-      `"#{$androidbin}" list targets`.split(/\n/).each do |line|
+      `"#{$androidbin}" list target`.split(/\n/).each do |line|
         line.chomp!
 
         if line =~ /^id:\s+([0-9]+)\s+or\s+\"(.*)\"/

--- a/platform/android/build/android_tools.rb
+++ b/platform/android/build/android_tools.rb
@@ -296,6 +296,9 @@ def  run_emulator(options = {})
       raise "ARM-based emulator image is not found for selected target: #{$androidtargets[get_api_level($emuversion)][:abis].inspect}" unless abi
     end
 
+    #replace whitespaces in AVD name with underscores
+    $avdname.tr!(' ', '_');
+
     unless File.directory?( File.join(ENV['HOME'], ".android", "avd", "#{$avdname}.avd" ) )
       puts "Emulator API level: #{get_api_level($emuversion)}"
       puts "Emulator params: #{$androidtargets[get_api_level($emuversion)].inspect}"


### PR DESCRIPTION
replace whitespaces in AVD name with underscores