### PR TITLE
avoid StringIndexOutOfBoundsException when value length is less than 5

### DIFF
--- a/lib/commonAPI/barcode/ext/platform/android/src/com/rho/barcode/emdk3/EMDK3ScannerSettings.java
+++ b/lib/commonAPI/barcode/ext/platform/android/src/com/rho/barcode/emdk3/EMDK3ScannerSettings.java
@@ -3110,9 +3110,10 @@ public class EMDK3ScannerSettings
 					if(values[0].endsWith("/")) value = "/" + values[1];
 					else value = values[1];
 				}
-				value = value.substring(5);
-				if(!value.equalsIgnoreCase(Environment.getExternalStorageDirectory().getAbsolutePath() + "/"+"decode.wav"))
-				config.scanParams.decodeAudioFeedbackUri = value;
+				if(value.length() >= 5)
+					value = value.substring(5);
+				if(!value.equalsIgnoreCase(Environment.getExternalStorageDirectory().getAbsolutePath() + "/" + "decode.wav"))
+					config.scanParams.decodeAudioFeedbackUri = value;
 				return true;
 			}
 


### PR DESCRIPTION
I run into exception using the barcode extension: It seems that `DecodeAudioFeedbackUri.set` may be called with an unexpected value; in that case, the framework throws a tough exception when trying to access a subString 