### PR TITLE
Fix double image rotation on Android

### DIFF
--- a/lib/commonAPI/mediacapture/ext/platform/android/src/com/rho/camera/CameraRhoListener.java
+++ b/lib/commonAPI/mediacapture/ext/platform/android/src/com/rho/camera/CameraRhoListener.java
@@ -593,6 +593,7 @@ public class CameraRhoListener extends AbstractRhoListener implements IRhoListen
 					Bitmap scaledBitmap = Bitmap.createScaledBitmap(bitmap, newWidth, newHeight, true);
 
 					saveTransformedBitmap(bitmapPath, scaledBitmap, bitmap, rotate_angle);
+					rotate_angle = 0;
 				}
 			} catch (Exception e) {
 				// TODO: handle exception
@@ -614,6 +615,7 @@ public class CameraRhoListener extends AbstractRhoListener implements IRhoListen
 				Bitmap bitmap = BitmapFactory.decodeFile(bitmapPath);
 				Bitmap gray = toGrayscale(bitmap);
 				saveTransformedBitmap(bitmapPath, gray, bitmap, rotate_angle);
+				rotate_angle = 0;
 			} catch (Exception e) {
 				// TODO: handle exception
 				e.printStackTrace();


### PR DESCRIPTION
Double rotation of image occurs if:
useRealBitmapResize = true
useRotationBitmapByEXIF = tue
are used together.