### PR TITLE
Fix file descriptor issues. Increase FD limit, fix race condition in …

### DIFF
--- a/platform/android/Rhodes/jni/include/rhodes/JNIRhodes.h
+++ b/platform/android/Rhodes/jni/include/rhodes/JNIRhodes.h
@@ -43,7 +43,7 @@
 #include <genconfig.h>
 #endif
 
-static int const RHO_FD_BASE = 512;
+static int const RHO_FD_BASE = 4096;
 
 JavaVM *jvm();
 void store_thr_jnienv(JNIEnv *env);

--- a/platform/android/Rhodes/src/com/rhomobile/rhodes/webview/GoogleWebView.java
+++ b/platform/android/Rhodes/src/com/rhomobile/rhodes/webview/GoogleWebView.java
@@ -1003,6 +1003,10 @@ public class GoogleWebView implements IRhoWebView {
         // lost foreground - restore keyboard settings !
         restoreKeyboardSettings();
 
+        mWebView.onPause();
+        mWebView.pauseTimers();
+        mWebView.setLayerType(View.LAYER_TYPE_NONE, null);
+
 
         //AndroidFunctionalityManager.getAndroidFunctionality().pauseWebView(mWebView,true);
     }
@@ -1010,6 +1014,10 @@ public class GoogleWebView implements IRhoWebView {
     @Override
     public void onResume() {
         setupOurTauKeyboard();
+
+        mWebView.setLayerType(View.LAYER_TYPE_HARDWARE, null);
+        mWebView.resumeTimers();
+        mWebView.onResume();
 
         //AndroidFunctionalityManager.getAndroidFunctionality().pauseWebView(mWebView,false);
     }

--- a/platform/shared/curl/lib/curl_threads.h
+++ b/platform/shared/curl/lib/curl_threads.h
@@ -23,7 +23,10 @@
  ***************************************************************************/
 #include "curl_setup.h"
 
-#if defined(USE_THREADS_POSIX)
+#if defined(USE_THREADS_POSIX) || defined(HAVE_PTHREAD_H)
+#  ifdef HAVE_PTHREAD_H
+#    include <pthread.h>
+#  endif
 #  define CURL_STDCALL
 #  define curl_mutex_t           pthread_mutex_t
 #  define curl_thread_t          pthread_t *

--- a/platform/shared/curl/lib/urldata.h
+++ b/platform/shared/curl/lib/urldata.h
@@ -25,6 +25,7 @@
 /* This file is for lib internal stuff */
 
 #include "curl_setup.h"
+#include "curl_threads.h"
 
 #define PORT_FTP 21
 #define PORT_FTPS 990
@@ -1176,6 +1177,9 @@ struct connectdata {
   struct http_connect_state *connect_state; /* for HTTP CONNECT */
   struct connectbundle *bundle; /* The bundle we are member of */
   int negnpn; /* APLN or NPN TLS negotiated protocol, CURL_HTTP_VERSION* */
+
+  curl_mutex_t socket_mutex; /* mutex protecting the sockets */
+  unsigned long tempsock_owner[2];  // Thread IDs for tempsock ownership
 
 #ifdef USE_UNIX_SOCKETS
   char *unix_domain_socket;


### PR DESCRIPTION
…curl lib, fix race condition in google web view java

This fixes 3 issues related to file descriptors:

- File descriptor limit increased. On devices with large number of native features (like 4 cameras), the peak file descriptor limit of 512 is not sufficient. 
- Race conditions in curl lib that causes fdsan to be triggered in sync errors: https://forums.tau-platform.com/thread/318/fdsan-crashes-android-30
- Race conditions in google web view because the start/stop messages are not sent to parent webview. Fixes issue on fast devices with random fdsan crashes happen when app loses/gains focus on android.